### PR TITLE
security: add .github/CODEOWNERS assigning @Pranav-14 as exclusive code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# 👑 LocalLoop Code Owners
+# Requires @Pranav-14 approval for all pull requests and code changes across the codebase.
+
+* @Pranav-14


### PR DESCRIPTION
## 🔒 Add Repository CODEOWNERS

This PR provisions `.github/CODEOWNERS` assigning `@Pranav-14` as the exclusive mandatory code owner across all files in the repository.